### PR TITLE
This PR resolves #63, #337, #410, #411, #418, #420, and related to #402, #409

### DIFF
--- a/Aikuma/AndroidManifest.xml
+++ b/Aikuma/AndroidManifest.xml
@@ -39,134 +39,213 @@
 				android:configChanges="orientation"
 				android:label="@string/app_name"
 				android:parentActivityName="org.lp20.aikuma.MainActivity">
+            <meta-data
+                android:name="android.support.PARENT_ACTIVITY"
+                android:value="org.lp20.aikuma.MainActivity" />
 		</activity>
 		<activity android:name="org.lp20.aikuma.ui.ListenRespeakingActivity"
 				android:configChanges="orientation"
 				android:label="@string/app_name"
 				android:parentActivityName="org.lp20.aikuma.MainActivity">
+            <meta-data
+                android:name="android.support.PARENT_ACTIVITY"
+                android:value="org.lp20.aikuma.MainActivity" />
 		</activity>
 		<activity android:name="org.lp20.aikuma.ui.CloudSearchActivity"
 				android:configChanges="orientation"
 				android:label="@string/app_name"
 				android:parentActivityName="org.lp20.aikuma.MainActivity">
+            <meta-data
+                android:name="android.support.PARENT_ACTIVITY"
+                android:value="org.lp20.aikuma.MainActivity" />
 		</activity>
 		<activity android:name="org.lp20.aikuma.ui.RecordActivity"
 				android:configChanges="orientation"
 				android:label="@string/app_name"
 				android:parentActivityName="org.lp20.aikuma.MainActivity">
+            <meta-data
+                android:name="android.support.PARENT_ACTIVITY"
+                android:value="org.lp20.aikuma.MainActivity" />
 		</activity>
 		<activity android:name="org.lp20.aikuma.ui.RecordVideoActivity"
 		    	android:configChanges="orientation"
-				
 				android:label="@string/app_name"
 				android:parentActivityName="org.lp20.aikuma.MainActivity">
+            <meta-data
+                android:name="android.support.PARENT_ACTIVITY"
+                android:value="org.lp20.aikuma.MainActivity" />
 		</activity>
 		<activity android:name="org.lp20.aikuma.ui.SettingsActivity"
 				android:configChanges="orientation"
 				android:label="@string/app_name"
 				android:parentActivityName="org.lp20.aikuma.MainActivity">
+            <meta-data
+                android:name="android.support.PARENT_ACTIVITY"
+                android:value="org.lp20.aikuma.MainActivity" />
 		</activity>
 		<activity android:name="org.lp20.aikuma.ui.RecordingMetadataActivity1"
 				android:configChanges="orientation"
 				android:label="@string/app_name"
 				android:parentActivityName="org.lp20.aikuma.MainActivity">
+            <meta-data
+                android:name="android.support.PARENT_ACTIVITY"
+                android:value="org.lp20.aikuma.MainActivity" />
 		</activity>
 		<activity android:name="org.lp20.aikuma.ui.RecordingMetadataActivity2"
 				android:configChanges="orientation"
 				android:label="@string/app_name"
 				android:parentActivityName="org.lp20.aikuma.MainActivity">
+            <meta-data
+                android:name="android.support.PARENT_ACTIVITY"
+                android:value="org.lp20.aikuma.MainActivity" />
 		</activity>
 		<activity android:name="org.lp20.aikuma.ui.RecordingMetadataActivity3"
 				android:configChanges="orientation"
 				android:label="@string/app_name"
 				android:parentActivityName="org.lp20.aikuma.MainActivity">
+            <meta-data
+                android:name="android.support.PARENT_ACTIVITY"
+                android:value="org.lp20.aikuma.MainActivity" />
 		</activity>
 		<activity android:name="org.lp20.aikuma.ui.RecordingMetadataActivity4"
 				android:configChanges="orientation"
 				android:label="@string/app_name"
 				android:parentActivityName="org.lp20.aikuma.MainActivity">
+            <meta-data
+                android:name="android.support.PARENT_ACTIVITY"
+                android:value="org.lp20.aikuma.MainActivity" />
 		</activity>
 		<activity android:name="org.lp20.aikuma.ui.LanguageFilterList"
 				android:configChanges="orientation"
 				android:label="@string/app_name"
 				android:parentActivityName="org.lp20.aikuma.MainActivity">
+            <meta-data
+                android:name="android.support.PARENT_ACTIVITY"
+                android:value="org.lp20.aikuma.MainActivity" />
 		</activity>
 		<activity android:name="org.lp20.aikuma.ui.RecordingSpeakersActivity"
 				android:configChanges="orientation"
 				android:label="@string/app_name"
 				android:parentActivityName="org.lp20.aikuma.MainActivity">
+            <meta-data
+                android:name="android.support.PARENT_ACTIVITY"
+                android:value="org.lp20.aikuma.MainActivity" />
 		</activity>
 		<activity android:name="org.lp20.aikuma.ui.MainSpeakersActivity"
 				android:configChanges="orientation"
 				android:label="@string/app_name"
 				android:parentActivityName="org.lp20.aikuma.MainActivity">
+            <meta-data
+                android:name="android.support.PARENT_ACTIVITY"
+                android:value="org.lp20.aikuma.MainActivity" />
 		</activity>
 		<activity android:name="org.lp20.aikuma.ui.AddSpeakerActivity1"
 				android:configChanges="orientation"
 				android:label="@string/app_name"
 				android:parentActivityName="org.lp20.aikuma.MainActivity">
+            <meta-data
+                android:name="android.support.PARENT_ACTIVITY"
+                android:value="org.lp20.aikuma.MainActivity" />
 		</activity>
 		<activity android:name="org.lp20.aikuma.ui.AddSpeakerActivity2"
 				android:configChanges="orientation"
 				android:label="@string/app_name"
 				android:parentActivityName="org.lp20.aikuma.MainActivity">
+            <meta-data
+                android:name="android.support.PARENT_ACTIVITY"
+                android:value="org.lp20.aikuma.MainActivity" />
 		</activity>
 		<activity android:name="org.lp20.aikuma.ui.AddSpeakerActivity3"
 				android:configChanges="orientation"
 				android:label="@string/app_name"
 				android:parentActivityName="org.lp20.aikuma.MainActivity">
+            <meta-data
+                android:name="android.support.PARENT_ACTIVITY"
+                android:value="org.lp20.aikuma.MainActivity" />
 		</activity>
 		<activity android:name="org.lp20.aikuma.ui.AddSpeakerActivity4"
 				android:configChanges="orientation"
 				android:label="@string/app_name"
 				android:parentActivityName="org.lp20.aikuma.MainActivity">
+            <meta-data
+                android:name="android.support.PARENT_ACTIVITY"
+                android:value="org.lp20.aikuma.MainActivity" />
 		</activity>
 		<activity android:name="org.lp20.aikuma.ui.ThumbRespeakActivity"
 				android:configChanges="orientation"
 				android:label="@string/app_name"
 				android:parentActivityName="org.lp20.aikuma.MainActivity">
+            <meta-data
+                android:name="android.support.PARENT_ACTIVITY"
+                android:value="org.lp20.aikuma.MainActivity" />
 		</activity>
 		<activity android:name="org.lp20.aikuma.ui.PhoneRespeakActivity"
 				android:configChanges="orientation"
 				android:label="@string/app_name"
 				android:parentActivityName="org.lp20.aikuma.MainActivity">
+            <meta-data
+                android:name="android.support.PARENT_ACTIVITY"
+                android:value="org.lp20.aikuma.MainActivity" />
 		</activity>
 		<activity android:name="org.lp20.aikuma.ui.AddCustomLanguageActivity"
 				android:configChanges="orientation"
 				android:label="@string/app_name"
 				android:parentActivityName="org.lp20.aikuma.MainActivity">
+            <meta-data
+                android:name="android.support.PARENT_ACTIVITY"
+                android:value="org.lp20.aikuma.MainActivity" />
 		</activity>
 		<activity android:name="org.lp20.aikuma.ui.DefaultLanguagesActivity"
 				android:configChanges="orientation"
 				android:label="@string/app_name"
 				android:parentActivityName="org.lp20.aikuma.MainActivity">
+            <meta-data
+                android:name="android.support.PARENT_ACTIVITY"
+                android:value="org.lp20.aikuma.MainActivity" />
 		</activity>
 		<activity android:name="org.lp20.aikuma.ui.CloudSettingsActivity"
 				android:configChanges="orientation"
 				android:label="@string/app_name"
 				android:parentActivityName="org.lp20.aikuma.MainActivity">
+            <meta-data
+                android:name="android.support.PARENT_ACTIVITY"
+                android:value="org.lp20.aikuma.MainActivity" />
 		</activity>
 		<activity android:name="org.lp20.aikuma.ui.SyncSettingsActivity"
 				android:configChanges="orientation"
 				android:label="@string/app_name"
 				android:parentActivityName="org.lp20.aikuma.MainActivity">
+            <meta-data
+                android:name="android.support.PARENT_ACTIVITY"
+                android:value="org.lp20.aikuma.MainActivity" />
 		</activity>
 		<activity android:name="org.lp20.aikuma.ui.AboutActivity"
 				android:configChanges="orientation"
 				android:label="@string/app_name"
 				android:parentActivityName="org.lp20.aikuma.MainActivity">
+            <meta-data
+                android:name="android.support.PARENT_ACTIVITY"
+                android:value="org.lp20.aikuma.MainActivity" />
 		</activity>
 		<activity android:name="org.lp20.aikuma.ui.HttpServerActivity"
 				android:label="@string/http_server_activity_title"
 				android:parentActivityName="org.lp20.aikuma.MainActivity" >
-				<meta-data android:name="android.support.PARENT_ACTIVITY"
-					android:value="org.lp20.aikuma.MainActivity" />
+            <meta-data
+                android:name="android.support.PARENT_ACTIVITY"
+                android:value="org.lp20.aikuma.MainActivity" />
 		</activity>
 		<activity android:name="org.lp20.aikuma.ui.HowtoActivity"
 				android:label="@string/http_server_activity_title"
 				android:parentActivityName="org.lp20.aikuma.MainActivity" >
+            <meta-data
+                android:name="android.support.PARENT_ACTIVITY"
+                android:value="org.lp20.aikuma.MainActivity" />
+		</activity>
+		<activity android:name="org.lp20.aikuma.ui.TestActivity"
+		    android:label="testUI"
+		    android:parentActivityName=".AikumaActivity" >
 				<meta-data android:name="android.support.PARENT_ACTIVITY"
-					android:value="org.lp20.aikuma.MainActivity" />
+					android:value="MainActivity" />
 		</activity>
 		<activity android:name="org.lp20.aikuma.ui.DebugInfo"
 				android:label="@string/title_activity_debug_info"

--- a/Aikuma/res/layout/cloud_settings.xml
+++ b/Aikuma/res/layout/cloud_settings.xml
@@ -9,12 +9,15 @@
 	    android:layout_height="wrap_content"
 	    android:text="Automatic Google-cloud sync" />
 
-	<CheckBox
+    <!-- 
+    <CheckBox
 	    android:id="@+id/sync_checkBox"
 	    android:layout_width="wrap_content"
 	    android:layout_height="wrap_content"
 	    android:text="Enable Sync" 
 	    android:onClick="onSyncCheckBoxClicked" />
+     -->
+	
 	
 	<CheckBox
 	    android:id="@+id/wifi_checkBox"
@@ -22,7 +25,12 @@
 	    android:layout_height="wrap_content"
 	    android:text="Allow sync over cellular-networks" 
 	    android:onClick="onWifiCheckBoxClicked" />
-    
-    
+
+	<Button
+	    android:id="@+id/syncNowButton"
+	    android:layout_width="match_parent"
+	    android:layout_height="wrap_content"
+	    android:text="@string/syncNow"
+		android:onClick="onSyncNowButton" />
 
 </LinearLayout>

--- a/Aikuma/res/layout/settings.xml
+++ b/Aikuma/res/layout/settings.xml
@@ -69,10 +69,4 @@
 			android:textSize="15sp"
 		/>
 	</LinearLayout>
-	<CheckBox
-	    android:id="@+id/proximity_checkbox"
-	    android:layout_width="wrap_content"
-	    android:layout_height="wrap_content"
-	    android:text="Turn on the proximity in recording" 
-	    android:onClick="onProximityCheckBox" />
 </LinearLayout>

--- a/Aikuma/res/menu/main.xml
+++ b/Aikuma/res/menu/main.xml
@@ -20,8 +20,6 @@
 	    android:title="@string/connect"/>
 	<item android:id="@+id/gplus_signin_menu"
 	    android:title="@string/gplus_signin_menu_label"/>
-	<item android:id="@+id/cloud_sync_menu"
-	    android:title="@string/cloud_sync_label"/>
 	<item android:id="@+id/cloud_sync_setting_menu"
 	    android:title="@string/cloud_sync_setting_label"/>
 	<item android:id="@+id/ftp_sync_setting_menu"
@@ -39,6 +37,9 @@
 	<item android:id="@+id/help"
 		android:icon="@drawable/question"
 		android:title="@string/help"/>
+	<item android:id="@+id/testUI"
+	    android:visible="false"
+	    android:title="testUI"/>
 	<item android:id="@+id/debugInfo"
 		android:visible="false"
 		android:title="Debug Info"/>

--- a/Aikuma/res/values/strings.xml
+++ b/Aikuma/res/values/strings.xml
@@ -39,7 +39,7 @@
 	<string name="audio_import_label">Import Audio</string>
 	<string name="gplus_signin_menu_label">Google Sign-in</string>
 	<string name="cloud_sync_label">GoogleCloud Sync</string>
-	<string name="cloud_sync_setting_label">GoogleCloud Settings</string>
+	<string name="cloud_sync_setting_label">Sync Settings</string>
 	<string name="ftp_sync_setting_label">FTP Sync Settings</string>
 	<string name="language_setting_label">Language Settings</string>
 	<string name="indexing_label">Item Re-indexing</string>

--- a/Aikuma/src/org/lp20/aikuma/MainActivity.java
+++ b/Aikuma/src/org/lp20/aikuma/MainActivity.java
@@ -268,7 +268,8 @@ public class MainActivity extends ListActivity {
 	public void onListItemClick(ListView l, View v, int position, long id){
 		Recording recording = (Recording) getListAdapter().getItem(position);
 		if(emailAccount == null) {
-			Aikuma.showAlertDialog(this, "You need to select your account");
+			Aikuma.showAlertDialog(this, 
+					"Please sign in to your Google account using the settings menu");
 			
 			return;
 		}
@@ -458,7 +459,7 @@ public class MainActivity extends ListActivity {
     }
 	
     /**
-     * Start an activity which allows a user to pick up an account
+     * Start an activity which allows a user to pick an account
      */
     private void pickUserAccount() {
         String[] accountTypes = new String[]{"com.google"};
@@ -492,7 +493,7 @@ public class MainActivity extends ListActivity {
                     		Toast.LENGTH_SHORT).show();
                 }
             } else if (resultCode == RESULT_CANCELED) {
-                Toast.makeText(this, "You must pick up an account", 
+                Toast.makeText(this, "You must pick an account", 
                 		Toast.LENGTH_SHORT).show();
             }
             

--- a/Aikuma/src/org/lp20/aikuma/model/FileModel.java
+++ b/Aikuma/src/org/lp20/aikuma/model/FileModel.java
@@ -27,7 +27,7 @@ public class FileModel implements Parcelable {
 	 */
 	public static final String METADATA_SUFFIX = "-metadata.json";
 	/** */
-	public static final String MAPPING_SUFFIX = "-mapping.txt";
+	public static final String MAPPING_SUFFIX = "-mapping.json";
 	/** */
 	public static final String TRANSCRIPT_SUFFIX = "-transcript.txt";
 	/** */

--- a/Aikuma/src/org/lp20/aikuma/model/Segments.java
+++ b/Aikuma/src/org/lp20/aikuma/model/Segments.java
@@ -12,6 +12,8 @@ import java.util.LinkedHashMap;
 import java.util.Iterator;
 import java.util.UUID;
 import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.json.simple.JSONArray;
+import org.json.simple.JSONObject;
 import org.lp20.aikuma.util.FileIO;
 
 /**
@@ -33,12 +35,19 @@ public class Segments {
 		this();
 		this.respeaking = respeaking;
 		try {
-			readSegments(new File(respeaking.getRecordingsPath(), 
+			readJSONSegments(new File(respeaking.getRecordingsPath(), 
 					respeaking.getGroupId() + "/" +
 					respeaking.getId() + "-mapping.txt"));
 		} catch (IOException e) {
-			//Issue with reading mapping.
-			throw new RuntimeException(e);
+			// Temporary solution (If file is not in JSON format, try older format)
+			try {
+				readSegments(new File(respeaking.getRecordingsPath(), 
+						respeaking.getGroupId() + "/" +
+						respeaking.getId() + "-mapping.txt"));
+			} catch (IOException e1) {
+				//Issue with reading mapping.
+				throw new RuntimeException(e1);
+			}
 		}
 	}
 
@@ -117,6 +126,32 @@ public class Segments {
 						, Long.parseLong(respeakingSegment[1])));
 		}
 	}
+	
+	private void readJSONSegments(File path) throws IOException {
+		JSONObject jsonObj = FileIO.readJSONObject(path);
+		JSONArray jsonSegmentArray = (JSONArray) jsonObj.get(JSON_MAPPING_KEY);
+		segmentMap = new LinkedHashMap<Segment, Segment>();
+		
+		for (Object jsonElem : jsonSegmentArray) {
+			JSONObject jsonSegmentPair = (JSONObject) jsonElem;
+			
+			JSONArray jsonSourceSegment = 
+					(JSONArray) jsonSegmentPair.get(JSON_ORIGINAL_KEY);
+			JSONArray jsonTargetSegment = 
+					(JSONArray) jsonSegmentPair.get(JSON_RESPEAKING_KEY);
+			
+			if (jsonSourceSegment.size() + jsonTargetSegment.size() != 4) {
+				throw new RuntimeException("Segment format is corrupted");
+			}
+			
+			segmentMap.put(
+					new Segment((Long) jsonSourceSegment.get(0), 
+							(Long) jsonSourceSegment.get(1)),
+					new Segment((Long) jsonTargetSegment.get(0), 
+							(Long) jsonTargetSegment.get(1)));
+			
+		}
+	}
 
 	/**
 	 * Writes the segment mapping to file.
@@ -125,7 +160,8 @@ public class Segments {
 	 * @throws	IOException	If the segments cannot be written to file.
 	 */
 	public void write(File path) throws IOException {
-		FileIO.write(path, toString());
+		//FileIO.write(path, toString());
+		FileIO.writeJSONObject(path, toJSONObject());
 	}
 
 	/**
@@ -207,6 +243,38 @@ public class Segments {
 		}
 		return mapString;
 	}
+	
+	/**
+	 * Get JSON representation of the segments structure
+	 * 
+	 * @return	JSON object of the segments
+	 */
+	private JSONObject toJSONObject() {
+		JSONObject jsonObj = new JSONObject();
+		JSONArray jsonSegmentArray = new JSONArray();
+		Segment respeakingSegment;
+		for (Segment originalSegment : segmentMap.keySet()) {
+			respeakingSegment = getRespeakingSegment(originalSegment);
+			
+			JSONObject jsonSegmentPair = new JSONObject();
+			JSONArray jsonSourceSegment = new JSONArray();
+			JSONArray jsonTargetSegment = new JSONArray();
+			
+			jsonSourceSegment.add(originalSegment.getStartSample());
+			jsonSourceSegment.add(originalSegment.getEndSample());
+			jsonTargetSegment.add(respeakingSegment.getStartSample());
+			jsonTargetSegment.add(respeakingSegment.getEndSample());
+			
+			jsonSegmentPair.put(JSON_ORIGINAL_KEY, jsonSourceSegment);
+			jsonSegmentPair.put(JSON_RESPEAKING_KEY, jsonTargetSegment);
+			
+			jsonSegmentArray.add(jsonSegmentPair);
+		}
+		
+		jsonObj.put(JSON_MAPPING_KEY, jsonSegmentArray);
+		
+		return jsonObj;
+	}
 
 	/**
 	 * An exception thrown if the segment mapping file is incorrectly
@@ -226,4 +294,8 @@ public class Segments {
 	private LinkedHashMap<Segment, Segment> segmentMap;
 	private Segment finalOriginalSegment;
 	private Recording respeaking;
+	
+	private static final String JSON_MAPPING_KEY = "mapping";
+	private static final String JSON_ORIGINAL_KEY = "source";
+	private static final String JSON_RESPEAKING_KEY = "target";
 }

--- a/Aikuma/src/org/lp20/aikuma/model/Segments.java
+++ b/Aikuma/src/org/lp20/aikuma/model/Segments.java
@@ -37,7 +37,7 @@ public class Segments {
 		try {
 			readJSONSegments(new File(respeaking.getRecordingsPath(), 
 					respeaking.getGroupId() + "/" +
-					respeaking.getId() + "-mapping.txt"));
+					respeaking.getId() + FileModel.MAPPING_SUFFIX));
 		} catch (IOException e) {
 			// Temporary solution (If file is not in JSON format, try older format)
 			try {

--- a/Aikuma/src/org/lp20/aikuma/service/BootReceiver.java
+++ b/Aikuma/src/org/lp20/aikuma/service/BootReceiver.java
@@ -28,14 +28,17 @@ public class BootReceiver extends BroadcastReceiver {
 	public void onReceive(Context context, Intent intent) {
 		Log.i(TAG, "BootReceiver started");
 		if (intent.getAction().equals("android.net.conn.CONNECTIVITY_CHANGE")) {
+			/*
 			SharedPreferences preferences = 
 					PreferenceManager.getDefaultSharedPreferences(context);
-			boolean isBackupEnabled = 
-					preferences.getBoolean(AikumaSettings.BACKUP_MODE_KEY, false);
-			boolean isAutoDownloadEnabled = 
-					preferences.getBoolean(AikumaSettings.AUTO_DOWNLOAD_MODE_KEY, false);
+			
+			AikumaSettings.isBackupEnabled = 
+					preferences.getBoolean(AikumaSettings.BACKUP_MODE_KEY, true);
+			AikumaSettings.isAutoDownloadEnabled = 
+					preferences.getBoolean(AikumaSettings.AUTO_DOWNLOAD_MODE_KEY, true);
+			*/
 
-			if(isBackupEnabled && isAutoDownloadEnabled) {
+			if(AikumaSettings.isBackupEnabled && AikumaSettings.isAutoDownloadEnabled) {
 				Intent serviceIntent = new Intent(context, GoogleCloudService.class);
 				serviceIntent.putExtra(GoogleCloudService.ACTION_KEY, "sync");
 				serviceIntent.putStringArrayListExtra(GoogleCloudService.ACCOUNT_KEY, 

--- a/Aikuma/src/org/lp20/aikuma/ui/CloudSettingsActivity.java
+++ b/Aikuma/src/org/lp20/aikuma/ui/CloudSettingsActivity.java
@@ -1,24 +1,16 @@
 package org.lp20.aikuma.ui;
 
-import java.io.IOException;
-
 import org.lp20.aikuma.Aikuma;
-import org.lp20.aikuma.service.BootReceiver;
-import org.lp20.aikuma.service.GoogleCloudService;
 import org.lp20.aikuma.util.AikumaSettings;
 import org.lp20.aikuma2.R;
 
-import android.app.AlarmManager;
-import android.app.PendingIntent;
-import android.content.ComponentName;
-import android.content.Intent;
 import android.content.SharedPreferences;
 import android.content.SharedPreferences.Editor;
-import android.content.pm.PackageManager;
 import android.os.Bundle;
 import android.preference.PreferenceManager;
 import android.util.Log;
 import android.view.View;
+import android.widget.Button;
 import android.widget.CheckBox;
 
 /**
@@ -43,16 +35,22 @@ public class CloudSettingsActivity extends AikumaActivity {
 		preferences =
 				PreferenceManager.getDefaultSharedPreferences(this);
 		prefsEditor = preferences.edit();
+		
+		if(AikumaSettings.getCurrentUserId() == null || 
+				!AikumaSettings.isBackupEnabled || !AikumaSettings.isAutoDownloadEnabled) {
+			Button syncButton = (Button) findViewById(R.id.syncNowButton);
+			syncButton.setEnabled(false);
+		}
+		//setupSyncCheckBox();
+		setupWifiCheckBox();
 	}
 
 	@Override
 	public void onResume() {
-		super.onResume();
-		
-		setupSyncCheckBox();
-		setupWifiCheckBox();
+		super.onResume();	
 	}
 	
+	/*
 	private void setupSyncCheckBox() {
 		CheckBox syncCheckBox = (CheckBox)
 				findViewById(R.id.sync_checkBox);
@@ -65,7 +63,7 @@ public class CloudSettingsActivity extends AikumaActivity {
 				preferences.getBoolean(AikumaSettings.AUTO_DOWNLOAD_MODE_KEY, false);
 		
 		syncCheckBox.setChecked(AikumaSettings.isBackupEnabled);
-	}
+	}*/
 	
 	private void setupWifiCheckBox() {
 		wifiCheckBox = (CheckBox)
@@ -79,12 +77,13 @@ public class CloudSettingsActivity extends AikumaActivity {
 		
 		wifiCheckBox.setChecked(!AikumaSettings.isOnlyWifi);
 	}
-
+	
 	/**
 	 * Adjusts the settings when the sync checkbox is checked.
 	 * 
 	 * @param checkBox	The checkbox 
 	 */
+	/*
 	public void onSyncCheckBoxClicked(View checkBox) {
 		boolean checked = ((CheckBox) checkBox).isChecked();
 		Log.i(TAG, "sync-checkbox: " + checked);
@@ -117,7 +116,7 @@ public class CloudSettingsActivity extends AikumaActivity {
 			wifiCheckBox.setChecked(false);
 			wifiCheckBox.setEnabled(false);
 		}
-	}
+	}*/
 	
 	/**
 	 * Callback function for the checkbox allowing sync over cellular network
@@ -137,5 +136,16 @@ public class CloudSettingsActivity extends AikumaActivity {
 			prefsEditor.commit();
 		}
 
+	}
+	
+	/**
+	 * Callback function for the SyncNow button
+	 * 
+	 * @param button	Cloud sync button
+	 */
+	public void onSyncNowButton(View button) {
+		Aikuma.syncRefresh(this, true);
+		//intent = new Intent(activity, CloudSyncSettingsActivity.class);
+		//activity.startActivity(intent);
 	}
 }

--- a/Aikuma/src/org/lp20/aikuma/ui/ListenActivity.java
+++ b/Aikuma/src/org/lp20/aikuma/ui/ListenActivity.java
@@ -4,8 +4,15 @@
 */
 package org.lp20.aikuma.ui;
 
+import android.text.Editable;
+import android.text.InputType;
+import android.text.TextUtils;
+import android.text.TextWatcher;
 import android.util.Log;
+import android.app.AlertDialog;
+import android.app.Dialog;
 import android.app.FragmentTransaction;
+import android.content.DialogInterface;
 import android.content.Intent;
 import android.content.SharedPreferences;
 import android.os.Bundle;
@@ -19,6 +26,7 @@ import android.view.WindowManager.LayoutParams;
 import android.widget.AdapterView;
 import android.widget.AdapterView.OnItemClickListener;
 import android.widget.ArrayAdapter;
+import android.widget.EditText;
 import android.widget.ImageButton;
 import android.widget.ListView;
 import android.widget.MediaController;
@@ -193,7 +201,10 @@ public class ListenActivity extends AikumaActivity {
 		if(googleAuthToken != null) {
 			QuickActionItem archiveAct = 
 					new QuickActionItem("share", R.drawable.aikuma_32);
+			QuickActionItem privateShareAct =
+					new QuickActionItem("share", R.drawable.speakers_32g);
 			quickMenu.addActionItem(archiveAct);
+			quickMenu.addActionItem(privateShareAct);
 		}
 		
 		
@@ -210,6 +221,8 @@ public class ListenActivity extends AikumaActivity {
 					onShareButtonPressed(null);
 				} else if (pos == 3) {
 					onArchiveButtonPressed(null);
+				} else if (pos == 4) {
+					onPrivateShareButtonPressed(null);
 				}
 			}
 		});
@@ -369,7 +382,8 @@ public class ListenActivity extends AikumaActivity {
 	 * @param	view	The share button
 	 */
 	public void onShareButtonPressed(View view) {
-		String urlToShare = "http://example.com/" + recording.getGroupId();
+		String urlToShare = "http://server/item/" + 
+				recording.getGroupId() + "#" + recording.getRespeakingId();
 		Intent intent = new Intent();
 		intent.setAction(Intent.ACTION_SEND);
 		intent.setType("text/plain");
@@ -396,6 +410,51 @@ public class ListenActivity extends AikumaActivity {
 		// Disable the button instantly because it can take a while until archive is finished
 		quickMenu.setItemEnabledAt(3, false);
 		quickMenu.setItemImageResourceAt(3, R.drawable.aikuma_grey);
+	}
+	
+	public void onPrivateShareButtonPressed(View view) {
+		final EditText emailInput = new EditText(this);
+		emailInput.setInputType(InputType.TYPE_CLASS_TEXT | 
+				InputType.TYPE_TEXT_VARIATION_EMAIL_ADDRESS);
+
+		final AlertDialog dialog = new AlertDialog.Builder(this)
+				.setTitle("Private Share")
+				.setMessage("Share the recording with ")
+				.setView(emailInput)
+				.setPositiveButton("Share", new DialogInterface.OnClickListener() {
+					public void onClick(DialogInterface dialog, int which) {
+						// TODO: Share the recording
+						String msg = String.format("Share %s with %s", 
+								recording.getId(), emailInput.getText());
+						Toast.makeText(ListenActivity.this, 
+								msg, Toast.LENGTH_LONG).show();
+					}
+				})
+				.setNegativeButton("Cancel", null)
+				.create();
+		
+		emailInput.addTextChangedListener(new TextWatcher() {
+			@Override
+			public void beforeTextChanged(CharSequence s, int start, int count,
+					int after) {}
+
+			@Override
+			public void onTextChanged(CharSequence s, int start, int before,
+					int count) {}
+
+			@Override
+			public void afterTextChanged(Editable s) {
+				if(!TextUtils.isEmpty(s) && 
+						android.util.Patterns.EMAIL_ADDRESS.matcher(s).matches()) {
+					dialog.getButton(Dialog.BUTTON_POSITIVE).setEnabled(true);
+				} else {
+					dialog.getButton(Dialog.BUTTON_POSITIVE).setEnabled(false);
+				}
+			}
+		});
+		
+		dialog.show();
+		dialog.getButton(Dialog.BUTTON_POSITIVE).setEnabled(false);
 	}
 	
 	private void updateStarButton() {

--- a/Aikuma/src/org/lp20/aikuma/ui/ListenActivity.java
+++ b/Aikuma/src/org/lp20/aikuma/ui/ListenActivity.java
@@ -412,6 +412,11 @@ public class ListenActivity extends AikumaActivity {
 		quickMenu.setItemImageResourceAt(3, R.drawable.aikuma_grey);
 	}
 	
+	/**
+	 * Callback for the private-share quickAction button
+	 *
+	 * @param	view	The share button
+	 */
 	public void onPrivateShareButtonPressed(View view) {
 		final EditText emailInput = new EditText(this);
 		emailInput.setInputType(InputType.TYPE_CLASS_TEXT | 

--- a/Aikuma/src/org/lp20/aikuma/ui/ListenRespeakingActivity.java
+++ b/Aikuma/src/org/lp20/aikuma/ui/ListenRespeakingActivity.java
@@ -363,6 +363,11 @@ public class ListenRespeakingActivity extends AikumaActivity{
 		}
 	}
 	
+	/**
+	 * Callback for the private-share button
+	 *
+	 * @param recording	Recording object which will be shared
+	 */
 	public void onPrivateShareButtonPressed(Recording recording) {
 		final EditText emailInput = new EditText(this);
 		emailInput.setInputType(InputType.TYPE_CLASS_TEXT | 

--- a/Aikuma/src/org/lp20/aikuma/ui/MainSpeakersActivity.java
+++ b/Aikuma/src/org/lp20/aikuma/ui/MainSpeakersActivity.java
@@ -4,18 +4,16 @@
 */
 package org.lp20.aikuma.ui;
 
-import android.app.ListActivity;
 import android.content.Intent;
 import android.os.Bundle;
-import android.util.Log;
-import android.view.Menu;
-import android.view.MenuItem;
 import android.view.View;
 import android.widget.ArrayAdapter;
 import android.widget.ListView;
 
 import java.util.Collections;
 import java.util.List;
+
+import org.lp20.aikuma.MainActivity;
 import org.lp20.aikuma.model.Speaker;
 import org.lp20.aikuma.util.AikumaSettings;
 import org.lp20.aikuma2.R;
@@ -60,6 +58,15 @@ public class MainSpeakersActivity extends AikumaListActivity {
 
 	@Override
 	protected void onListItemClick(ListView l, View v, int position, long id) {
+		Speaker speaker = (Speaker) l.getItemAtPosition(position);
+		
+		Intent intent = new Intent(this, MainActivity.class);
+		intent.addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP | 
+				Intent.FLAG_ACTIVITY_CLEAR_TOP);
+		intent.putExtra("speakerId", speaker.getId());
+		startActivity(intent);
+		
+		
 		/*
 		Intent intent = new Intent();
 		intent.putExtra("speaker", (Speaker)l.getItemAtPosition(position));

--- a/Aikuma/src/org/lp20/aikuma/ui/MenuBehaviour.java
+++ b/Aikuma/src/org/lp20/aikuma/ui/MenuBehaviour.java
@@ -8,16 +8,12 @@ import java.io.IOException;
 
 import android.app.Activity;
 import android.app.AlertDialog;
-import android.app.SearchManager;
 import android.content.DialogInterface;
 import android.content.Intent;
-import android.content.res.Resources;
 import android.net.Uri;
-import android.util.Log;
 import android.view.Menu;
 import android.view.MenuInflater;
 import android.view.MenuItem;
-import android.widget.SearchView;
 
 import org.lp20.aikuma.Aikuma;
 import org.lp20.aikuma.MainActivity;
@@ -134,11 +130,6 @@ public class MenuBehaviour {
 				}
 				
 				return true;
-			case R.id.cloud_sync_menu:
-				((MainActivity)activity).syncRefresh(true);
-				//intent = new Intent(activity, CloudSyncSettingsActivity.class);
-				//activity.startActivity(intent);
-				return true;
 			case R.id.cloud_sync_setting_menu:
 				intent = new Intent(activity, CloudSettingsActivity.class);
 				activity.startActivity(intent);
@@ -153,6 +144,10 @@ public class MenuBehaviour {
 				} catch (IOException e) {
 					Aikuma.showAlertDialog(activity, e.getMessage());
 				}
+				return true;
+			case R.id.testUI:
+				intent = new Intent(activity, TestActivity.class);
+				activity.startActivity(intent);
 				return true;
 			case R.id.debugInfo:
 				intent = new Intent(activity, DebugInfo.class);

--- a/Aikuma/src/org/lp20/aikuma/ui/MenuBehaviour.java
+++ b/Aikuma/src/org/lp20/aikuma/ui/MenuBehaviour.java
@@ -84,7 +84,7 @@ public class MenuBehaviour {
 			case R.id.record:
 				if(AikumaSettings.getCurrentUserId() == null) {
 					Aikuma.showAlertDialog(activity,
-							"You need to select your account");
+							"Please sign in to your Google account using the settings menu");
 					return true;
 				}
 				intent = new Intent(activity, RecordActivity.class);
@@ -93,7 +93,7 @@ public class MenuBehaviour {
 			case R.id.speakers:
 				if(AikumaSettings.getCurrentUserId() == null) {
 					Aikuma.showAlertDialog(activity,
-							"You need to select your account");
+							"Please sign in to your Google account using the settings menu");
 					return true;
 				}
 				intent = new Intent(activity, MainSpeakersActivity.class);

--- a/Aikuma/src/org/lp20/aikuma/ui/RecordActivity.java
+++ b/Aikuma/src/org/lp20/aikuma/ui/RecordActivity.java
@@ -253,6 +253,7 @@ public class RecordActivity extends AikumaActivity {
 
 	@Override
 	public boolean dispatchTouchEvent(MotionEvent event) {
+		Log.i(TAG, "isNear: " + proximityDetector.isNear());
 		if (proximityDetector.isNear()) {
 			return false;
 		} else {
@@ -260,6 +261,7 @@ public class RecordActivity extends AikumaActivity {
 		}
 	}
 	
+	private static final String TAG = RecordActivity.class.getSimpleName();
 	static final int VIDEO_REQUEST_CODE = 0;
 
 	private boolean recording;

--- a/Aikuma/src/org/lp20/aikuma/ui/RecordActivity.java
+++ b/Aikuma/src/org/lp20/aikuma/ui/RecordActivity.java
@@ -26,7 +26,6 @@ import org.lp20.aikuma.MainActivity;
 import org.lp20.aikuma.model.Recording;
 import org.lp20.aikuma2.R;
 import org.lp20.aikuma.ui.sensors.ProximityDetector;
-import org.lp20.aikuma.util.AikumaSettings;
 
 /**
  * The activity that allows audio to be recorded
@@ -123,35 +122,29 @@ public class RecordActivity extends AikumaActivity {
 	public void onPause() {
 		super.onPause();
 		pause();
-		
-		if(AikumaSettings.isProximityOn)
-			this.proximityDetector.stop();
+		this.proximityDetector.stop();
 	}
 
 	@Override
 	public void onResume() {
 		super.onResume();
-		
-		if(AikumaSettings.isProximityOn) {
-			this.proximityDetector = new ProximityDetector(this) {
-				public void near(float distance) {
-					WindowManager.LayoutParams params = getWindow().getAttributes();
-					params.flags |= LayoutParams.FLAG_KEEP_SCREEN_ON;
-					params.screenBrightness = 0;
-					getWindow().setAttributes(params);
-					//record();
-				}
-				public void far(float distance) {
-					WindowManager.LayoutParams params = getWindow().getAttributes();
-					params.flags |= LayoutParams.FLAG_KEEP_SCREEN_ON;
-					params.screenBrightness = 1;
-					getWindow().setAttributes(params);
-					//pause();
-				}
-			};
-			this.proximityDetector.start();
-		}
-		
+		this.proximityDetector = new ProximityDetector(this) {
+			public void near(float distance) {
+				WindowManager.LayoutParams params = getWindow().getAttributes();
+				params.flags |= LayoutParams.FLAG_KEEP_SCREEN_ON;
+				params.screenBrightness = 0;
+				getWindow().setAttributes(params);
+				//record();
+			}
+			public void far(float distance) {
+				WindowManager.LayoutParams params = getWindow().getAttributes();
+				params.flags |= LayoutParams.FLAG_KEEP_SCREEN_ON;
+				params.screenBrightness = 1;
+				getWindow().setAttributes(params);
+				//pause();
+			}
+		};
+		this.proximityDetector.start();
 		
 	}
 
@@ -260,7 +253,7 @@ public class RecordActivity extends AikumaActivity {
 
 	@Override
 	public boolean dispatchTouchEvent(MotionEvent event) {
-		if (AikumaSettings.isProximityOn && proximityDetector.isNear()) {
+		if (proximityDetector.isNear()) {
 			return false;
 		} else {
 			return super.dispatchTouchEvent(event);

--- a/Aikuma/src/org/lp20/aikuma/ui/RecordingArrayAdapter.java
+++ b/Aikuma/src/org/lp20/aikuma/ui/RecordingArrayAdapter.java
@@ -5,7 +5,6 @@
 package org.lp20.aikuma.ui;
 
 import android.content.Context;
-import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -22,7 +21,6 @@ import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 
-import org.lp20.aikuma.model.Language;
 import org.lp20.aikuma.model.Recording;
 import org.lp20.aikuma.model.Speaker;
 import org.lp20.aikuma2.R;
@@ -223,23 +221,19 @@ public class RecordingArrayAdapter extends ArrayAdapter<Recording> {
 
 			@Override
 			protected FilterResults performFiltering(CharSequence constraint) {
-				// TODO Auto-generated method stub
-				constraint = constraint.toString().toLowerCase();
 				Filter.FilterResults results = new Filter.FilterResults();
 				
 				if(constraint == null || constraint.length() == 0) {
 					results.values = recordings;
 				} else {
+					constraint = constraint.toString().toUpperCase();
+					
 					List<Recording> filteredRecordings = 
 							new ArrayList<Recording>();
 					for(int i=0; i<recordings.size(); i++) {
 						Recording item = recordings.get(i);
-						List<Language> languages = item.getLanguages();
-						for(Language lang : languages) {
-							if(lang.getCode().contains(constraint)) {
-								filteredRecordings.add(item);
-								break;
-							}
+						if(item.getSpeakersIds().contains(constraint)) {
+							filteredRecordings.add(item);
 						}
 					}
 					results.values = filteredRecordings;

--- a/Aikuma/src/org/lp20/aikuma/ui/sensors/ProximityDetector.java
+++ b/Aikuma/src/org/lp20/aikuma/ui/sensors/ProximityDetector.java
@@ -12,6 +12,7 @@ import android.hardware.SensorEventListener;
 import android.hardware.SensorManager;
 import android.content.Context;
 import android.util.FloatMath;
+import android.util.Log;
 
 /**
  * A simple proximity detector.
@@ -23,6 +24,8 @@ import android.util.FloatMath;
  */
 public class ProximityDetector {
 
+	private static final String TAG = ProximityDetector.class.getSimpleName();
+	
 	/**
 	 * The sensor manager that provides the readings.
 	 */
@@ -46,7 +49,7 @@ public class ProximityDetector {
 
 		public void onSensorChanged(SensorEvent sensorEvent) {
 			float distance = sensorEvent.values[0];
-
+			Log.i(TAG, "close: " + close + ", threshold: " + distance);
 			if (!close && distance <= threshold) {
 				near(distance);
 				close = true; // report only once
@@ -116,11 +119,12 @@ public class ProximityDetector {
 	 */
 	public void start() {
 		this.close = false;
-		sensorManager.registerListener(
+		boolean success = sensorManager.registerListener(
 				sensorListener,
 				sensorManager.getDefaultSensor(Sensor.TYPE_PROXIMITY),
 				SensorManager.SENSOR_DELAY_NORMAL
 		);
+		Log.i(TAG, "registered: " + success);
 	}
 
 	/**

--- a/Aikuma/src/org/lp20/aikuma/util/AikumaSettings.java
+++ b/Aikuma/src/org/lp20/aikuma/util/AikumaSettings.java
@@ -17,10 +17,6 @@ import org.lp20.aikuma.storage.GoogleDriveStorage;
  */
 public class AikumaSettings {
 	/**
-	 * Test value
-	 */
-	public static boolean isProximityOn = false;
-	/**
 	 * Setting value for backup
 	 */
 	public static boolean isBackupEnabled = true;


### PR DESCRIPTION
#410 
- Sync is now on by default

#418 
- During speaker/recording creation activities, the screen will be fixed in portrait mode

#402 
- UI for private share is implemented
- If private-share quickaction button is pressed on a recording, dialog will pop up to allow an user to type in an email address he wants to share with.

#409 
- If an user selects one speaker in the speaker-list, the aikuma goes back to main-screen(first screen) with filtered items by the speaker.
- If back-button is pressed, the filtering will be cancelled and the main-screen will show all the items 