### PR TITLE
integrate cloud-storage-0.10.0

### DIFF
--- a/Aikuma/build.gradle
+++ b/Aikuma/build.gradle
@@ -1,0 +1,75 @@
+buildscript {
+    repositories {
+        mavenCentral()
+    }
+    dependencies {
+        classpath 'com.android.tools.build:gradle:1.0.1'
+    }
+}
+apply plugin: 'android'
+apply plugin: 'eclipse'
+
+repositories {
+    mavenCentral()
+    mavenLocal()
+}
+
+dependencies {
+    compile files('libs/nanohttpd-2.0.5.jar')
+    compile 'org.lp20:aikuma-cloud-storage:0.10.0'
+    compile files('libs/musicg-1.4.2.0.jar')
+    compile 'com.google.android.gms:play-services:+'
+    compile('com.googlecode.json-simple:json-simple:1.1.1') {
+        exclude module: 'junit'
+    }
+    compile 'au.com.bytecode:opencsv:2.4'
+    compile 'com.google.guava:guava:18.0'
+    compile 'commons-io:commons-io:2.4'
+    compile 'commons-net:commons-net:3.3'
+    compile 'org.apache.commons:commons-lang3:3.3.2'
+    compile('org.apache.ftpserver:ftpserver-core:1.0.6') {
+        exclude module: 'ftplet-api'
+    }
+}
+
+android {
+    buildToolsVersion "21.1.2"
+    compileSdkVersion 16
+
+    buildTypes {
+        release {
+            minifyEnabled true
+            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.txt'
+        }
+        debug {
+            minifyEnabled true
+            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules-debug.txt'
+        }
+    }
+
+    sourceSets {
+        main {
+            manifest.srcFile 'AndroidManifest.xml'
+            java.srcDirs = ['src']
+            resources.srcDirs = ['src']
+            aidl.srcDirs = ['src']
+            renderscript.srcDirs = ['src']
+            res.srcDirs = ['res']
+            assets.srcDirs = ['assets']
+        }
+
+        instrumentTest.setRoot('tests')
+    }
+
+    packagingOptions {
+        exclude 'META-INF/LICENSE.txt'
+        exclude 'META-INF/NOTICE.txt'
+        exclude 'META-INF/LICENSE'
+        exclude 'META-INF/NOTICE'
+    }
+
+    lintOptions {
+        abortOnError false
+    }
+}
+

--- a/Aikuma/gradle.properties
+++ b/Aikuma/gradle.properties
@@ -1,0 +1,1 @@
+org.gradle.daemon=true

--- a/Aikuma/proguard-rules-debug.txt
+++ b/Aikuma/proguard-rules-debug.txt
@@ -1,0 +1,22 @@
+# To enable ProGuard in your project, edit project.properties
+# to define the proguard.config property as described in that file.
+#
+# Add project specific ProGuard rules here.
+# By default, the flags in this file are appended to flags specified
+# in ${sdk.dir}/tools/proguard/proguard-android.txt
+# You can edit the include path and order by changing the ProGuard
+# include property in project.properties.
+#
+# For more details, see
+#   http://developer.android.com/guide/developing/tools/proguard.html
+-dontwarn **
+
+# Add any project specific keep options here:
+-dontobfuscate
+
+# If your project uses WebView with JS, uncomment the following
+# and specify the fully qualified class name to the JavaScript interface
+# class:
+#-keepclassmembers class fqcn.of.javascript.interface.for.webview {
+#   public *;
+#}

--- a/Aikuma/proguard-rules.txt
+++ b/Aikuma/proguard-rules.txt
@@ -1,0 +1,21 @@
+# To enable ProGuard in your project, edit project.properties
+# to define the proguard.config property as described in that file.
+#
+# Add project specific ProGuard rules here.
+# By default, the flags in this file are appended to flags specified
+# in ${sdk.dir}/tools/proguard/proguard-android.txt
+# You can edit the include path and order by changing the ProGuard
+# include property in project.properties.
+#
+# For more details, see
+#   http://developer.android.com/guide/developing/tools/proguard.html
+-dontwarn **
+
+# Add any project specific keep options here:
+
+# If your project uses WebView with JS, uncomment the following
+# and specify the fully qualified class name to the JavaScript interface
+# class:
+#-keepclassmembers class fqcn.of.javascript.interface.for.webview {
+#   public *;
+#}

--- a/Aikuma/src/org/lp20/aikuma/MainActivity.java
+++ b/Aikuma/src/org/lp20/aikuma/MainActivity.java
@@ -42,7 +42,7 @@ import java.util.List;
 import org.lp20.aikuma.Aikuma;
 import org.lp20.aikuma.model.Recording;
 import org.lp20.aikuma.service.GoogleCloudService;
-import org.lp20.aikuma.storage.GoogleAuth;
+import org.lp20.aikuma.storage.google.GoogleAuth;
 import org.lp20.aikuma.ui.ListenActivity;
 import org.lp20.aikuma.ui.MenuBehaviour;
 import org.lp20.aikuma.ui.RecordingArrayAdapter;

--- a/Aikuma/src/org/lp20/aikuma/service/GoogleCloudService.java
+++ b/Aikuma/src/org/lp20/aikuma/service/GoogleCloudService.java
@@ -29,7 +29,7 @@ import org.lp20.aikuma.model.FileModel.FileType;
 import org.lp20.aikuma.storage.Data;
 import org.lp20.aikuma.storage.DataStore;
 import org.lp20.aikuma.storage.FusionIndex2;
-import org.lp20.aikuma.storage.GoogleDriveStorage;
+import org.lp20.aikuma.storage.google.GoogleDriveStorage;
 import org.lp20.aikuma.storage.Index;
 import org.lp20.aikuma.storage.Utils;
 import org.lp20.aikuma.util.AikumaSettings;

--- a/Aikuma/src/org/lp20/aikuma/ui/CloudSearchActivity.java
+++ b/Aikuma/src/org/lp20/aikuma/ui/CloudSearchActivity.java
@@ -31,7 +31,7 @@ import org.lp20.aikuma.model.Recording;
 import org.lp20.aikuma.service.GoogleCloudService;
 import org.lp20.aikuma.storage.DataStore;
 import org.lp20.aikuma.storage.FusionIndex;
-import org.lp20.aikuma.storage.GoogleDriveStorage;
+import org.lp20.aikuma.storage.google.GoogleDriveStorage;
 import org.lp20.aikuma.storage.Index;
 import org.lp20.aikuma.storage.Utils;
 import org.lp20.aikuma.util.AikumaSettings;

--- a/Aikuma/src/org/lp20/aikuma/ui/DebugInfo.java
+++ b/Aikuma/src/org/lp20/aikuma/ui/DebugInfo.java
@@ -19,7 +19,7 @@ import android.widget.Toast;
 
 import org.lp20.aikuma.storage.DataStore;
 import org.lp20.aikuma.storage.FusionIndex2;
-import org.lp20.aikuma.storage.GoogleDriveStorage;
+import org.lp20.aikuma.storage.google.GoogleDriveStorage;
 import org.lp20.aikuma.storage.Index;
 import org.lp20.aikuma.util.AikumaSettings;
 import org.lp20.aikuma2.R;

--- a/Aikuma/src/org/lp20/aikuma/ui/TestActivity.java
+++ b/Aikuma/src/org/lp20/aikuma/ui/TestActivity.java
@@ -42,7 +42,7 @@ import java.util.List;
 import org.lp20.aikuma.Aikuma;
 import org.lp20.aikuma.model.Recording;
 import org.lp20.aikuma.service.GoogleCloudService;
-import org.lp20.aikuma.storage.GoogleAuth;
+import org.lp20.aikuma.storage.google.GoogleAuth;
 import org.lp20.aikuma.ui.ListenActivity;
 import org.lp20.aikuma.ui.MenuBehaviour;
 import org.lp20.aikuma.ui.RecordingArrayAdapter;

--- a/Aikuma/src/org/lp20/aikuma/util/AikumaSettings.java
+++ b/Aikuma/src/org/lp20/aikuma/util/AikumaSettings.java
@@ -5,7 +5,7 @@
 package org.lp20.aikuma.util;
 
 import org.lp20.aikuma.storage.FusionIndex;
-import org.lp20.aikuma.storage.GoogleDriveStorage;
+import org.lp20.aikuma.storage.google.GoogleDriveStorage;
 
 
 /**


### PR DESCRIPTION
- there were changes required by namespace changes in
  cloud-storage-0.10.0
- added gradle build script

This PR tries to upgrade cloud storage api to 0.10.0, which is still in PR #491. This PR should be merged only after PR #491 is merged.

The added gradle build script can be used to build the app from command line, e.g.

```
gradle assemble          # build both debug and release apks
gradle assembleDebug     # build debug apk
gradle assembleRelease   # build release apk
gradle installDebug      # install debug apk on the connected phone
gradle installRelease    # install release apk on the connected phone
```

Gradle has to be installed separately. Or, Android Studio might be able to use it without any modification.