### PR TITLE
This PR resolves #407, #478, #484, #490, #495

### DIFF
--- a/Aikuma/res/menu/main.xml
+++ b/Aikuma/res/menu/main.xml
@@ -32,7 +32,7 @@
 		android:title="@string/settings"/>
 		<!--android:showAsAction="always"/>-->
 	<item android:id="@+id/audio_import_menu"
-	    android:title="@string/audio_import_label"/>
+	    android:title="@string/import_label"/>
 	<item android:id="@+id/indexing_menu"
 	    android:title="@string/indexing_label"/>
 	<item android:id="@+id/help"

--- a/Aikuma/res/values/strings.xml
+++ b/Aikuma/res/values/strings.xml
@@ -37,7 +37,7 @@
 	<string name="language_name">Language name</string>
 	<string name="about">About</string>
 	<string name="connect">HTTP Server</string>
-	<string name="audio_import_label">Import Audio</string>
+	<string name="import_label">Import</string>
 	<string name="gplus_signin_menu_label">Google Sign-in</string>
 	<string name="cloud_sync_label">GoogleCloud Sync</string>
 	<string name="cloud_sync_setting_label">Sync Settings</string>

--- a/Aikuma/src/org/lp20/aikuma/model/Recording.java
+++ b/Aikuma/src/org/lp20/aikuma/model/Recording.java
@@ -696,7 +696,8 @@ public class Recording extends FileModel {
 			// Import the sample wave file into the new recording directory
 			String suffixExt = getSuffixExt(versionName, FileType.PREVIEW);
 			importWav(recordingUUID + suffixExt, getId() + suffixExt);
-			importImage(imageUUID);
+			if(imageUUID != null)	// image is optional
+				importImage(imageUUID);
 		} else {
 			// Try and import the mapping file
 			importMapping(recordingUUID, getId());
@@ -1879,7 +1880,7 @@ public class Recording extends FileModel {
 	/**
 	 * Keys of the recording metadata fields
 	 */
-	public static final String NAME_KEY = "name";
+	public static final String NAME_KEY = "title";
 	/** */
 	public static final String COMMENTS_KEY = "comments";
 	/** */

--- a/Aikuma/src/org/lp20/aikuma/model/RecordingCSVFile.java
+++ b/Aikuma/src/org/lp20/aikuma/model/RecordingCSVFile.java
@@ -1,0 +1,265 @@
+package org.lp20.aikuma.model;
+
+import java.io.File;
+import java.io.FileReader;
+import java.io.IOException;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.lp20.aikuma.Aikuma;
+import org.lp20.aikuma.util.AikumaSettings;
+
+import au.com.bytecode.opencsv.CSVReader;
+
+public class RecordingCSVFile {
+	
+	private static final String TAG = RecordingCSVFile.class.getSimpleName();
+	
+	private File mPath;
+	
+	private int fieldNum;
+	private Map<String, Integer> fieldOrder;
+	private List<MetadataChunk> metadataList;
+	private List<String> filenameList;
+	private static Map<String, Speaker> speakerMap = new HashMap<String, Speaker>();
+	
+	public RecordingCSVFile(File filepath, String filename) throws IOException {
+		if(AikumaSettings.getCurrentUserId() == null)
+			throw new IOException("Can't be created: UserID is necessary");
+		
+		mPath = filepath;
+		metadataList = new ArrayList<MetadataChunk>();
+		filenameList = new ArrayList<String>();
+		speakerMap.clear();
+		List<Speaker> deviceSpeakers = Speaker.readAll(AikumaSettings.getCurrentUserId());
+		for(Speaker speaker : deviceSpeakers) {
+			speakerMap.put(speaker.getName().toLowerCase(), speaker);
+		}
+		
+		
+		CSVReader csvReader = new CSVReader(new FileReader(new File(filepath, filename)), ',');
+		
+		String[] lineBuffer;
+		lineBuffer = csvReader.readNext();
+		fieldNum = lineBuffer.length;
+		fieldOrder = new HashMap<String, Integer>(fieldNum);
+		
+		boolean isHeaderValid = checkHeader(lineBuffer);
+		if(!isHeaderValid) {
+			csvReader.close();
+			throw new IOException("Parse-error: Header is invalid");
+		}
+			
+		while((lineBuffer = csvReader.readNext()) != null) {
+			// If filename is not given, just skip the row.
+			if(lineBuffer[fieldOrder.get(FILENAME_KEY)].isEmpty())
+				continue;
+			
+			boolean isFileExist = new File(mPath, 
+					lineBuffer[fieldOrder.get(FILENAME_KEY)] + "." + FileModel.AUDIO_EXT).exists();
+			if(fieldOrder.containsKey(IMAGE_KEY)) {
+				isFileExist &= new File(mPath, 
+						lineBuffer[fieldOrder.get(IMAGE_KEY)] + "." + FileModel.IMAGE_EXT).exists();
+			}
+			if(!isFileExist) {
+				csvReader.close();
+				throw new IOException("Open-error: " + lineBuffer[fieldOrder.get(FILENAME_KEY)]  + " doesn't exist");
+			}
+			try {
+				metadataList.add(new MetadataChunk(lineBuffer, fieldOrder, metadataProcList));		
+			} catch (IOException e) {
+				csvReader.close();
+				throw new IOException(e.getMessage());
+			}
+		}
+		csvReader.close();
+	}
+	
+	private boolean checkHeader(String[] header) {
+		for (int i = 0; i < fieldNum; i++) {
+			String fieldname = header[i].toLowerCase();
+			if(keySet.contains(fieldname)) {
+				fieldOrder.put(fieldname, i);
+			}
+		}
+		if(!fieldOrder.keySet().containsAll(requiredKeySet))
+			return false;
+		return true;
+	}
+	
+	public int getNumOfSources() {
+		return metadataList.size();
+	}
+	
+	public MetadataChunk getMetadata(int i) {
+		return metadataList.get(i);
+	}
+	
+	public List<MetadataChunk> getMetadataChunks() {
+		return metadataList;
+	}
+	
+	private interface metadataProcessor<T> {
+		public T processField(String metadataStr) throws IOException;
+	}
+	
+	public class MetadataChunk {
+		private String mFileName;
+		private String mImageName;
+		private String mTitle;
+		private String mComments;
+		private Date mDate;
+		private List<Language> mLanguages;
+		private List<Speaker> mSpeakers;
+		
+		public MetadataChunk(String filename, String imagename, String title, String comments, 
+				Date date, List<Language> languages, List<Speaker> speakers) {
+			mFileName = filename;
+			mImageName = imagename;
+			mTitle = title;
+			mComments = comments;
+			mDate = date;
+			mLanguages = languages;
+			mSpeakers = speakers;
+		}
+		
+		public MetadataChunk(String[] metadataFields, 
+				Map<String, Integer> fieldOrder, Map<String, metadataProcessor> fieldProcessor) throws IOException {
+			mFileName = (String) fieldProcessor.get(FILENAME_KEY).processField(
+					metadataFields[fieldOrder.get(FILENAME_KEY)]) + "." + FileModel.AUDIO_EXT;
+			if(filenameList.contains(mFileName))
+				throw new IOException("Parse-error: There are duplicate filenames (" + mFileName + ")");
+			filenameList.add(mFileName);
+			
+			if(fieldOrder.containsKey(IMAGE_KEY)) {
+				mImageName = (String) fieldProcessor.get(IMAGE_KEY).processField(
+						metadataFields[fieldOrder.get(IMAGE_KEY)]) + "." + FileModel.IMAGE_EXT;
+			}
+			mTitle = (String) fieldProcessor.get(TITLE_KEY).processField(
+					metadataFields[fieldOrder.get(TITLE_KEY)]);
+			mComments = (String) fieldProcessor.get(COMMENTS_KEY).processField(
+					metadataFields[fieldOrder.get(COMMENTS_KEY)]);
+			if(fieldOrder.containsKey(DESCRIPTION_KEY)) {
+				String description = (String) fieldProcessor.get(DESCRIPTION_KEY).processField(
+						metadataFields[fieldOrder.get(DESCRIPTION_KEY)]);
+				if(!mComments.isEmpty())
+					mComments = "\n" + mComments;
+				mComments = description + mComments; 
+			}
+			mDate = (Date) fieldProcessor.get(DATE_KEY).processField(
+					metadataFields[fieldOrder.get(DATE_KEY)]);
+			mLanguages = (List<Language>) fieldProcessor.get(LANGUAGES_KEY).processField(
+					metadataFields[fieldOrder.get(LANGUAGES_KEY)]);
+			mSpeakers = (List<Speaker>) fieldProcessor.get(SPEAKERS_KEY).processField(
+					metadataFields[fieldOrder.get(SPEAKERS_KEY)]);
+		}
+		
+		public String getFileName() { return mFileName; }
+		public String getImageName() { return mImageName; }
+		public String getTitle() { return mTitle; }
+		public String getComments() { return mComments; }
+		public Date getDate() { return mDate; }
+		public List<Language> getLanguages() { return mLanguages; }
+		public List<Speaker> getSpeakers() { return mSpeakers; }
+	}
+	
+	private static final String FILENAME_KEY = "filename";
+	private static final String IMAGE_KEY = "imagename";
+	private static final String TITLE_KEY = "title";
+	private static final String DATE_KEY = "date";
+	private static final String SPEAKERS_KEY = "speakers";
+	private static final String LANGUAGES_KEY = "languages";
+	private static final String DESCRIPTION_KEY = "description";
+	private static final String COMMENTS_KEY = "comments";
+	
+	private static final Set<String> requiredKeySet = new HashSet<String>();
+	private static final Set<String> keySet = new HashSet<String>();
+	static {
+		keySet.add(FILENAME_KEY);
+		keySet.add(IMAGE_KEY);
+		keySet.add(TITLE_KEY);
+		keySet.add(DATE_KEY);
+		keySet.add(SPEAKERS_KEY);
+		keySet.add(LANGUAGES_KEY);
+		keySet.add(DESCRIPTION_KEY);
+		keySet.add(COMMENTS_KEY);
+		
+		requiredKeySet.add(FILENAME_KEY);
+		requiredKeySet.add(TITLE_KEY);
+		requiredKeySet.add(DATE_KEY);
+		requiredKeySet.add(SPEAKERS_KEY);
+		requiredKeySet.add(LANGUAGES_KEY);
+		requiredKeySet.add(COMMENTS_KEY);
+	}
+	
+	private static final HashMap<String, metadataProcessor> metadataProcList = 
+			new HashMap<String, metadataProcessor>();
+	static {
+		metadataProcessor<String> defaultProcessor = new metadataProcessor<String>() {
+			@Override
+			public String processField(String metadataStr) {
+				return metadataStr;
+			}
+		};
+		metadataProcList.put(FILENAME_KEY, defaultProcessor);
+		metadataProcList.put(IMAGE_KEY, defaultProcessor);
+		metadataProcList.put(TITLE_KEY, defaultProcessor);
+		metadataProcList.put(DATE_KEY, new metadataProcessor<Date>() {
+			private SimpleDateFormat dateParser = new SimpleDateFormat("yyyy-MM-dd");
+			@Override
+			public Date processField(String dateStr) throws IOException {
+				try {
+					return dateParser.parse(dateStr);
+				} catch (ParseException e) {
+					throw new IOException("Parse-error: date is not correctly formatted (" + dateStr + ")");
+				}
+			}
+		});
+		metadataProcList.put(SPEAKERS_KEY, new metadataProcessor<List<Speaker>>() {
+			@Override
+			public List<Speaker> processField(String metadataStr) throws IOException {
+				List<Speaker> speakerList = new ArrayList<Speaker>();
+				metadataStr = metadataStr.trim();
+				String[] speakerNames = metadataStr.split("\\s*,\\s*");
+				for(String spkName : speakerNames) {
+					String spkNameKey = spkName.toLowerCase();
+					if(speakerMap.containsKey(spkNameKey)) {
+						speakerList.add(speakerMap.get(spkNameKey));
+					} else {
+						throw new IOException("Parse-error: Speaker doesn't exist (" + spkName + ")");
+					}
+				}
+				return speakerList;
+			}
+		});
+		metadataProcList.put(LANGUAGES_KEY, new metadataProcessor<List<Language>>() {
+			@Override
+			public List<Language> processField(String metadataStr) throws IOException {
+				List<Language> langList = new ArrayList<Language>();
+				Map<String, String> langCodeMap = Aikuma.getLanguageCodeMap();
+				metadataStr = metadataStr.toLowerCase();
+				String[] langCodes = metadataStr.split("\\s*,\\s*");
+				for(String langCode : langCodes) {
+					String langName = langCodeMap.get(langCode);
+					
+					if(langName == null) {
+						throw new IOException("Parse-error: ISO639 code is not correct (" + langCode + ")");
+					} else {
+						// ??? Check duplicates ???
+						langList.add(new Language(langName, langCode));
+					}
+				}
+				return langList;
+			}
+		});
+		metadataProcList.put(DESCRIPTION_KEY, defaultProcessor);
+		metadataProcList.put(COMMENTS_KEY, defaultProcessor);
+	}
+}

--- a/Aikuma/src/org/lp20/aikuma/model/Speaker.java
+++ b/Aikuma/src/org/lp20/aikuma/model/Speaker.java
@@ -298,7 +298,9 @@ public class Speaker extends FileModel implements Comparable<Speaker> {
 		}
 		Speaker rhs = (Speaker) obj;
 		return new EqualsBuilder()
-				.append(id, rhs.id).append(name, rhs.name)
+				//.append(id, rhs.id)
+				.append(name, rhs.name)
+				.append(ownerId, rhs.ownerId)
 				.isEquals();
 	}
 

--- a/Aikuma/src/org/lp20/aikuma/model/SpeakerCSVFile.java
+++ b/Aikuma/src/org/lp20/aikuma/model/SpeakerCSVFile.java
@@ -1,0 +1,145 @@
+package org.lp20.aikuma.model;
+
+import java.io.File;
+import java.io.FileReader;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.lp20.aikuma.util.AikumaSettings;
+
+import au.com.bytecode.opencsv.CSVReader;
+
+public class SpeakerCSVFile {
+	
+	private static final String TAG = SpeakerCSVFile.class.getSimpleName();
+	
+	private File mPath;
+	
+	private int fieldNum;
+	private Map<String, Integer> fieldOrder;
+	private List<MetadataChunk> metadataList;
+	private static Map<String, Speaker> speakerMap = new HashMap<String, Speaker>();
+	
+	public SpeakerCSVFile(File filepath, String filename) throws IOException {
+		if(AikumaSettings.getCurrentUserId() == null)
+			throw new IOException("Can't be created: UserID is necessary");
+		
+		mPath = filepath;
+		metadataList = new ArrayList<MetadataChunk>();
+		speakerMap.clear();
+
+		CSVReader csvReader = new CSVReader(new FileReader(new File(filepath, filename)), ',');
+		
+		String[] lineBuffer;
+		lineBuffer = csvReader.readNext();
+		fieldNum = lineBuffer.length;
+		fieldOrder = new HashMap<String, Integer>(fieldNum);
+		
+		boolean isHeaderValid = checkHeader(lineBuffer);
+		if(!isHeaderValid) {
+			csvReader.close();
+			throw new IOException("Parse-error: Header is invalid");
+		}
+			
+		while((lineBuffer = csvReader.readNext()) != null) {
+			// If filename is not given, just skip the row.
+			if(lineBuffer[fieldOrder.get(SPEAKER_NAME_KEY)].isEmpty())
+				continue;
+			
+			try {
+				metadataList.add(new MetadataChunk(lineBuffer, fieldOrder, metadataProcList));
+			} catch(IOException e) {
+				csvReader.close();
+				throw new IOException(e.getMessage());
+			}
+		}
+		csvReader.close();
+	}
+	
+	private boolean checkHeader(String[] header) {
+		if(fieldNum != 1) return false;
+		
+		for (int i = 0; i < fieldNum; i++) {
+			String fieldname = header[i].toLowerCase();
+			if(keySet.contains(fieldname)) {
+				fieldOrder.put(fieldname, i);
+			}
+		}
+		if(!fieldOrder.keySet().containsAll(requiredKeySet))
+			return false;
+		return true;
+	}
+	
+	public int getNumOfSources() {
+		return metadataList.size();
+	}
+	
+	public MetadataChunk getMetadata(int i) {
+		return metadataList.get(i);
+	}
+	
+	public List<MetadataChunk> getMetadataChunks() {
+		return metadataList;
+	}
+	
+	private interface metadataProcessor<T> {
+		public T processField(String metadataStr) throws IOException;
+	}
+	
+	public class MetadataChunk {
+		private Speaker mSpeaker;
+		
+		public MetadataChunk(Speaker speaker) {
+			mSpeaker = speaker;
+		}
+		
+		public MetadataChunk(String[] metadataFields, 
+				Map<String, Integer> fieldOrder, Map<String, metadataProcessor> fieldProcessor) throws IOException {
+			mSpeaker = (Speaker) fieldProcessor.get(SPEAKER_NAME_KEY).processField(
+					metadataFields[fieldOrder.get(SPEAKER_NAME_KEY)]);
+		}
+		
+		public Speaker getSpeaker() { return mSpeaker; }
+	}
+	
+	private static final String SPEAKER_NAME_KEY = "speaker";
+	
+	private static final Set<String> requiredKeySet = new HashSet<String>();
+	private static final Set<String> keySet = new HashSet<String>();
+	static {
+		keySet.add(SPEAKER_NAME_KEY);
+		requiredKeySet.add(SPEAKER_NAME_KEY);
+	}
+	
+	private static final HashMap<String, metadataProcessor> metadataProcList = 
+			new HashMap<String, metadataProcessor>();
+	static {
+		metadataProcessor<String> defaultProcessor = new metadataProcessor<String>() {
+			@Override
+			public String processField(String metadataStr) {
+				return metadataStr;
+			}
+		};
+		metadataProcList.put(SPEAKER_NAME_KEY, new metadataProcessor<Speaker>() {
+			@Override
+			public Speaker processField(String metadataStr) {
+				String spkName = metadataStr.trim();
+				String spkNameKey = spkName.toLowerCase();
+				if(speakerMap.containsKey(spkNameKey)) {
+					return speakerMap.get(spkNameKey);
+				} else {
+					Speaker newSpeaker = new Speaker(spkName, "", new Date(), 
+							AikumaSettings.getLatestVersion(), AikumaSettings.getCurrentUserId());
+					speakerMap.put(spkNameKey, newSpeaker);
+					return newSpeaker;
+				}
+			}
+		});
+	}
+}

--- a/Aikuma/src/org/lp20/aikuma/ui/ListenActivity.java
+++ b/Aikuma/src/org/lp20/aikuma/ui/ListenActivity.java
@@ -363,14 +363,6 @@ public class ListenActivity extends AikumaActivity {
 		Log.i(TAG, 
 				"respeakingMode: " + respeakingMode +", rewindAmount: " + rewindAmount);
 
-		/*
-		Intent intent;
-		if (respeakingMode.equals("phone")) {
-			intent = new Intent(this, PhoneRespeakActivity.class);
-		} else {
-			// Lets just default to thumb respeaking
-			intent = new Intent(this, ThumbRespeakActivity.class);
-		}*/
 		Intent intent;
 		if(respeakingType.equals("respeak")) {
 			if (respeakingMode.equals("phone")) {
@@ -476,6 +468,8 @@ public class ListenActivity extends AikumaActivity {
 		// Disable the button instantly because it can take a while until archive is finished
 		quickMenu.setItemEnabledAt(3, false);
 		quickMenu.setItemImageResourceAt(3, R.drawable.aikuma_grey);
+		
+		Toast.makeText(this, "Queued for public sharing", Toast.LENGTH_LONG).show();
 	}
 	
 	/**

--- a/Aikuma/src/org/lp20/aikuma/ui/ListenRespeakingActivity.java
+++ b/Aikuma/src/org/lp20/aikuma/ui/ListenRespeakingActivity.java
@@ -404,6 +404,8 @@ public class ListenRespeakingActivity extends AikumaActivity{
 			respeakingQuickMenu.setItemEnabledAt(3, false);
 			respeakingQuickMenu.setItemImageResourceAt(3, R.drawable.aikuma_grey);
 		}
+		
+		Toast.makeText(this, "Queued for public sharing", Toast.LENGTH_LONG).show();
 	}
 	
 	/**

--- a/Aikuma/src/org/lp20/aikuma/ui/MenuBehaviour.java
+++ b/Aikuma/src/org/lp20/aikuma/ui/MenuBehaviour.java
@@ -11,6 +11,7 @@ import android.app.AlertDialog;
 import android.content.DialogInterface;
 import android.content.Intent;
 import android.net.Uri;
+import android.util.Log;
 import android.view.Menu;
 import android.view.MenuInflater;
 import android.view.MenuItem;
@@ -127,7 +128,12 @@ public class MenuBehaviour {
 				activity.startActivity(intent);
 				return true;
 			case R.id.audio_import_menu:
-				((MainActivity)activity).audioImport(null);
+				if(AikumaSettings.getCurrentUserId() == null) {
+					Aikuma.showAlertDialog(activity,
+							"Please sign in to your Google account using the settings menu");
+					return true;
+				}
+				((MainActivity)activity).fileImport(null);
 				return true;
 			case R.id.gplus_signin_menu:
 				if(signInState) {
@@ -237,6 +243,10 @@ public class MenuBehaviour {
 	 * @param state		true(signed-in), false(no sign-in)
 	 */
 	public void setSignInState(boolean state) {
+		if(menu == null) {
+			Log.e("MenuBehaviour", "called before menu is created"); // by MainActivity?
+			return;
+		}
 		this.signInState = state;
 		if(state) {
 			//TODO: get emailAccount from AikumaSettings

--- a/Aikuma/src/org/lp20/aikuma/util/AikumaSettings.java
+++ b/Aikuma/src/org/lp20/aikuma/util/AikumaSettings.java
@@ -164,7 +164,10 @@ public class AikumaSettings {
 	public static final String UPLOAD_OTHERS_KEY = "uploadOthers";
 	/** */
 	public static final String ARCHIVED_OTHERS_KEY = "archivedOthers";
-	
+	/** */
+	public static final String SOURCE_LANG_BUFFER_KEY = "sourceLanguages";
+	/** */
+	public static final String INTERPRET_LANG_BUFFER_KEY = "interpretLanguages";
 	
 	/**
 	 * Latest version name.


### PR DESCRIPTION
#407 
  - Steps: 
1. Put the source wave files and one csv file, containing a list of source metadata, in the same folder
2. Select the menu item 'import'
3. Select 'Recording'
4. If csv file is selected and the step 1 is done, all of the recording will be imported
5. If there is any error, toast will pop up with a feedback message

  - CSV file field headers: filename, imagename(optional), title, date, speakers, languages, comments
  - Field order is not important, but the corresponding values should be followed after the header
  - Date will have the format 'YYYY-MM-DD'
  - speakers and languages will be comma-separated strings enclosed by quotes (eg. "kor, eng, rus")
  - speakers should be imported/created before recordings are imported
![image](https://cloud.githubusercontent.com/assets/7444407/9173067/f735c6c6-3fba-11e5-9f0e-c55e20783dd8.png)

#495 
  - Steps: Same as the bulk import of recordings except for the step 1(only csv is necessary), 3 (select 'Speaker')
  - CSV file field header: speaker
  - The list of speaker names will be followed after the header in one column

  